### PR TITLE
Fix require call in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Download [citation.js](https://github.com/larsgw/citation.js/tree/archive), incl
 ```html
 <script src="path/to/citation.js" type="text/javascript"></script>
 <script>
-  const Cite = require('citation.js')
+  const Cite = require('citation-js')
 </script>
 ```
 


### PR DESCRIPTION
A dash is needed. Not a period.