### PR TITLE
[output:bibtex] Use CSL 'URL' instead of 'url'

### DIFF
--- a/src/get/modules/bibtex/json.js
+++ b/src/get/modules/bibtex/json.js
@@ -42,7 +42,7 @@ const getBibTeXJSON = function (src) {
     publisher: 'publisher',
     'publisher-place': 'address',
     title: 'title',
-    url: 'url',
+    URL: 'url',
     volume: 'volume'
   }
 


### PR DESCRIPTION
Fix #153