### PR TITLE
Fix of import comma separated records in bibtex

### DIFF
--- a/src/parse/modules/bibtex/text.js
+++ b/src/parse/modules/bibtex/text.js
@@ -162,9 +162,9 @@ const parseBibTeX = function (str) {
             
       // records can be also ended with comma
       if (stack.matches(',')) {
-        stack.consumeToken(',');
+        stack.consumeToken(',')
+        stack.consumeWhitespace()
       }
-      stack.consumeWhitespace()
 
       entries.push({type, label, properties})
     }

--- a/src/parse/modules/bibtex/text.js
+++ b/src/parse/modules/bibtex/text.js
@@ -159,6 +159,12 @@ const parseBibTeX = function (str) {
 
       stack.consumeToken('}', {spaced: false})
       stack.consumeWhitespace()
+            
+      // records can be also ended with comma
+      if (stack.matches(',')) {
+        stack.consumeToken(',');
+      }
+      stack.consumeWhitespace()
 
       entries.push({type, label, properties})
     }


### PR DESCRIPTION
In some bibtex files, records are separated by comma (for example export from orcid.org).